### PR TITLE
fix empty brokers check bug

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -14,7 +14,7 @@ func NewConsumerGroup(brokers []string, groupId string) (sarama.ConsumerGroup, e
 	if groupId == "" {
 		return nil, ErrNoGroupID
 	}
-	if brokers == nil {
+	if len(brokers) == 0 {
 		return nil, ErrNoBrokers
 	}
 

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -33,7 +33,7 @@ func TestNewConsumerGroup(t *testing.T) {
 		{
 			name: "should-not-work-without-brokers",
 			args: args{
-				brokers: nil,
+				brokers: []string{},
 				groupId: "kafka-do",
 			},
 			wantErr: true,

--- a/producer_test.go
+++ b/producer_test.go
@@ -13,7 +13,7 @@ func TestNewProducer(t *testing.T) {
 	}{
 		{
 			name:         "should-not-work-without-brokers",
-			brokers:      nil,
+			brokers:      []string{},
 			maxMegabytes: 1,
 			wantErr:      true,
 		},


### PR DESCRIPTION
Sorry for not creating an issue for this PR. It is just a simple bug.

len() for nil slices is defined as zero. So it is recomended to check slices with len().

Here is a more detailed explanation for this: [Golang nil vs empty slice](https://medium.com/@habibridho/golang-nil-vs-empty-slice-87fd51c0a4d)